### PR TITLE
Use attr() as base of data()

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -1,3 +1,5 @@
+import attr from './attr';
+
 /**
  * Get or set the value of a data attribute of an element.
  *
@@ -7,11 +9,5 @@
  * @return {*} The value of the data attribute if getting.
  */
 export default function data(element, key, value) {
-  const {dataset} = element;
-
-  if (value === undefined) {
-    return dataset[key];
-  }
-
-  dataset[key] = value;
+  return attr(element, `data-${key}`, value);
 }

--- a/test/data.js
+++ b/test/data.js
@@ -5,12 +5,12 @@ import data from '../lib/data';
 
 test('gets the value of a data attribute', t => {
   const scope = fragment(`
-    <div data-foo=bar></div>
+    <div data-foo-bar=baz></div>
   `);
 
   const element = find(scope, 'div');
 
-  t.is(data(element, 'foo'), 'bar');
+  t.is(data(element, 'foo-bar'), 'baz');
   t.end();
 });
 
@@ -21,7 +21,7 @@ test('sets the value of a data attribute', t => {
 
   const element = find(scope, 'div');
 
-  data(element, 'foo', 'bar');
-  t.is(data(element, 'foo'), 'bar');
+  data(element, 'foo-bar', 'baz');
+  t.is(data(element, 'foo-bar'), 'baz');
   t.end();
 });


### PR DESCRIPTION
This ensures both better performance compared to the dataset API and keys can additionally be specified in dashed case instead of being forced camel case.