### PR TITLE
Only use `ms`-prefixed version of `matches()`

### DIFF
--- a/lib/matches.js
+++ b/lib/matches.js
@@ -6,11 +6,5 @@
  * @return {boolean} True if the element matches the selector.
  */
 export default function matches(element, selector) {
-  const matches =
-    element.matches ||
-    element.webkitMatchesSelector ||
-    element.mozMatchesSelector ||
-    element.msMatchesSelector;
-
-  return matches.call(element, selector);
+  return (element.matches || element.msMatchesSelector).call(element, selector);
 }


### PR DESCRIPTION
According to caniuse.com only IE still lacks support of the non-prefixed version of `matches()`: http://caniuse.com/#feat=matchesselector